### PR TITLE
Replace %20 in room JIDs with spaces

### DIFF
--- a/campfirer/muc.py
+++ b/campfirer/muc.py
@@ -70,6 +70,7 @@ class MUCService(component.Service):
     def parseCampfireName(self, jid):
         room_parts = jid.user.split(".")
         roomname = ".".join(room_parts[1:])
+        roomname = roomname.replace("%20", " ")
         account = room_parts[0]    
         return (account, roomname)
         


### PR DESCRIPTION
This makes it possible to join Campfire rooms with spaces in their
names, and thus closes bmuller/campfirer#1.
