### PR TITLE
Advertise rooms as password protected in disco info

### DIFF
--- a/campfirer/muc.py
+++ b/campfirer/muc.py
@@ -60,10 +60,20 @@ class MUCService(component.Service):
         response = self.iq('result', iq['id'])
         query = getattr(iq, 'query', None)
         if query is not None:
+            log.msg("disco query to %s" % iq['to'])
             query = response.addElement('query', DISCO_NS_INFO)
-            identity = domish.Element((None, 'identity'), attribs={'category': "conference", 'name': 'campfirenow.com interface MUC', 'type': "text"})
-            query.addChild(identity)
-            query.addChild(domish.Element((None, 'feature'), attribs={'var': NS_MUC}))
+            if '@' in iq['to']:
+                # Info for a room. Advertise "password protected" feature, to
+                # ensure that clients ask the user for the password.
+                response['from'] = iq['to']
+                identity = domish.Element((None, 'identity'), attribs={'category': "conference", 'name': 'campfire chat room', 'type': "text"})
+                query.addChild(identity)
+                query.addChild(domish.Element((None, 'feature'), attribs={'var': NS_MUC}))
+                query.addChild(domish.Element((None, 'feature'), attribs={'var': 'muc_passwordprotected'}))
+            else:
+                identity = domish.Element((None, 'identity'), attribs={'category': "conference", 'name': 'campfirenow.com interface MUC', 'type': "text"})
+                query.addChild(identity)
+                query.addChild(domish.Element((None, 'feature'), attribs={'var': NS_MUC}))
             response.send(iq['from'])
 
 


### PR DESCRIPTION
My Jabber client only asks me for a password if the disco info result
suggests that the room is password protected.  This change makes the
service return just that.
