### PR TITLE
Send room topic to client

### DIFF
--- a/campfirer/campfirenow/room.py
+++ b/campfirer/campfirenow/room.py
@@ -40,8 +40,12 @@ class CampfireRoom(CampfireClient):
             name = xmluser.name[0].text[0]
             participants[uid] = name
         self.participants.update(participants)
-        
-        self.topic = root.topic[0].text[0]
+
+        first_topic = root.topic[0]
+        try:
+            self.topic = first_topic.text[0]
+        except:
+            self.topic = ''
         if self.msgs.last_msg_id is not None:
             url = "room/%s/recent.xml?since_message_id=%s" % (self.room_id, self.msgs.last_msg_id)
         else:

--- a/campfirer/muc.py
+++ b/campfirer/muc.py
@@ -31,6 +31,7 @@ class MUCService(component.Service):
     implements(IService)
 
     def __init__(self, config):
+        self.last_topic = None
         self.config = config
         self.rooms = {}
         self.host = self.config['xmpp.muc.host']
@@ -122,6 +123,12 @@ class MUCService(component.Service):
             mfrom = room.participant_jid.userhostJID()
             mfrom.resource = msg.user.replace(" ", "") 
             self.sendMessage(mfrom, msg.body, room.source_jid, msg.tstamp)
+
+        if room.topic != self.last_topic:
+            self.last_topic = room.topic
+            topic = domish.Element((None, 'message'), attribs = {'from': room.participant_jid.userhost(), 'to': room.source_jid.full(), 'type': 'groupchat'})
+            topic.addElement('subject', content=room.topic)
+            self.xmlstream.send(topic)
 
 
     def sendPresence(self, pfrom, pto, statuses=None):


### PR DESCRIPTION
Incidentally, this also satisfies the requirement of XEP-0045 section
7.2.16 that the room send a message without <body> but with
<subject> (possibly empty) after sending message history to a newly
joined client.
